### PR TITLE
unbork lifetimes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ pub struct StdoutLayer<S: Subscriber> {
 #[derive(Debug, Default)]
 pub struct StderrLayer {}
 
-impl<'a, S: Subscriber + LookupSpan<'a>> Layer<S> for StdoutLayer<S> {
+impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for StdoutLayer<S> {
     fn on_close(&self, id: Id, ctx: Context<S>) {
         let span = self.inner.span(&id);
         dbg!(span);


### PR DESCRIPTION
This is essentially saying "for any arbitrary `&S`, the `S` must implement LookupSpan with the lifetime of that reference". Whereas, what you had was saying "for an `'a` that I am generic over, `S` must implement `LookupSpan` for that `'a`". but in your method, you didn't have an `&'a S`, you had an `&S`. So, the `&S` from the `on_event` method did not match the `&'a S` that your trait bound expected.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>